### PR TITLE
Include a test resource which should produce an error to test validationwebhook

### DIFF
--- a/_infra/templates/istio-test.yaml
+++ b/_infra/templates/istio-test.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Sidecar
+metadata:
+  label:
+    istio.io/rev: v120
+  name: sidecar-test
+  namespace: infra
+spec:
+  egress:
+  - hosts:
+    - ./google.fr
+  workloadSelector:
+    labels:
+      app: landing-jb.favre


### PR DESCRIPTION
I add a broken resource on purpose to check that validationwebhook blocks it, and see what happens to the HR.
By default, it shouldn't break tlsmonitor, but only block the HR reconciliation.
Removing the faulty resource should resume HR operations.

Expected result:
Resource should be blocked by validation webhook. If not, it would end up with following error from `istioctl analyze`:

```
Error [IST0101] (Sidecar infra/tlsmonitor) Referenced selector not found: "app=landing-jb.favre"
```