### PR TITLE
Add a known broken resource

### DIFF
--- a/_infra/templates/istio-broken.yaml
+++ b/_infra/templates/istio-broken.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: pro-partner
+  namespace: pro
+  labels:
+    istio.io/rev: v120
+spec:
+  hosts:
+    - pro-partner.pro.svc.cluster.local
+  http:
+    - name: "pro-partner-bookings-data-v2"
+      match:
+        - method:
+            exact: 'GET'
+          uri:
+            regex: '^\/api\/bookings\/v2\/[a-zA-Z0-9-]+$'
+      route:
+        - destination:
+            host: pro-partner.pro.svc.cluster.local
+    - name: "pro-partner-bookings-data-v3"
+      match:
+        - method:
+            exact: 'GET'
+          uri:
+            regex: '^\/api\/bookings\/v3\/[a-zA-Z0-9-]+$'
+    - name: "pro-partner-bookings-and-tripoffers-legacy"
+      match:
+        - method:
+            exact: 'GET'
+          uri:
+            regex: '^\/bookings-and-tripoffers$'
+      route:
+        - destination:
+            host: pro-partner.pro.svc.cluster.local
+    - name: "pro-partner-bookings-and-tripoffers-v4"
+      match:
+        - method:
+            exact: 'GET'
+          uri:
+            regex: '^\/bookings-and-tripoffers\/v4$'
+      route:
+        - destination:
+            host: pro-partner.pro.svc.cluster.local
+    - name: "pro-partner-catch-all"
+      route:
+        - destination:
+            host: "pro-partner.pro.svc.cluster.local"

--- a/_infra/templates/istio-broken.yaml
+++ b/_infra/templates/istio-broken.yaml
@@ -10,40 +10,9 @@ spec:
   hosts:
     - pro-partner.pro.svc.cluster.local
   http:
-    - name: "pro-partner-bookings-data-v2"
-      match:
-        - method:
-            exact: 'GET'
-          uri:
-            regex: '^\/api\/bookings\/v2\/[a-zA-Z0-9-]+$'
-      route:
-        - destination:
-            host: pro-partner.pro.svc.cluster.local
     - name: "pro-partner-bookings-data-v3"
       match:
         - method:
             exact: 'GET'
           uri:
             regex: '^\/api\/bookings\/v3\/[a-zA-Z0-9-]+$'
-    - name: "pro-partner-bookings-and-tripoffers-legacy"
-      match:
-        - method:
-            exact: 'GET'
-          uri:
-            regex: '^\/bookings-and-tripoffers$'
-      route:
-        - destination:
-            host: pro-partner.pro.svc.cluster.local
-    - name: "pro-partner-bookings-and-tripoffers-v4"
-      match:
-        - method:
-            exact: 'GET'
-          uri:
-            regex: '^\/bookings-and-tripoffers\/v4$'
-      route:
-        - destination:
-            host: pro-partner.pro.svc.cluster.local
-    - name: "pro-partner-catch-all"
-      route:
-        - destination:
-            host: "pro-partner.pro.svc.cluster.local"

--- a/_infra/templates/istio-broken.yaml
+++ b/_infra/templates/istio-broken.yaml
@@ -2,8 +2,8 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: pro-partner
-  namespace: pro
+  name: istio-broken
+  namespace: infra
   labels:
     istio.io/rev: v120
 spec:

--- a/_infra/templates/istio-test.yaml
+++ b/_infra/templates/istio-test.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
-  label:
+  labels:
     istio.io/rev: v120
   name: sidecar-test
   namespace: infra


### PR DESCRIPTION
Second attempt.
Expected result: the resource should not be deployed.

```
> istioctl validate -f istio-test.yaml 
"istio-test.yaml" is valid

> istioctl validate -f istio-broken.yaml 
Error: 1 error occurred:
	* VirtualService/infra/istio-broken: HTTP route, redirect or direct_response is required
```