### PR TITLE
fix: create sidecar even when no host is provided

### DIFF
--- a/_infra/Chart.yaml
+++ b/_infra/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A golang short program that monitor certificates
 name: tlsmonitor
-version: 1.3.2
+version: 1.3.3
 appVersion: 1.3.0

--- a/_infra/templates/istio-service-entry.yaml
+++ b/_infra/templates/istio-service-entry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.istio.serviceEntry .Values.hosts -}}
+{{- if and .Values.istio.enabled .Values.istio.serviceEntry -}}
 {{ $super := . }}
 {{- range .Values.hosts }}
 ---

--- a/_infra/templates/istio-sidecar.yaml
+++ b/_infra/templates/istio-sidecar.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.istio.enabled .Values.istio.sidecar .Values.hosts }}
+{{- if and .Values.istio.enabled .Values.istio.sidecar }}
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:

--- a/_infra/values.yaml
+++ b/_infra/values.yaml
@@ -25,16 +25,16 @@ checksFrequency: 24
 # Prometheus metrics
 metrics:
   enabled: true
-  prometheusOperator: true
+  prometheusOperator: false
   prometheusAnnotations: false
   port: 9090
   path: /metrics
 
 istio:
   enabled: false
-  sidecar: false
-  serviceEntry: false
-  outboundTrafficPolicy: ALLOW_ANY
+  sidecar: true
+  serviceEntry: true
+  outboundTrafficPolicy: REGISTRY_ONLY
 
 resources:
   requests:


### PR DESCRIPTION
\+ make the chart egress compliant by default as long as Istio is enabled

related to DBRE-3896