### PR TITLE
chore: include datadog/istio labels and annotations by default 

### DIFF
--- a/_infra/Chart.yaml
+++ b/_infra/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A golang short program that monitor certificates
 name: tlsmonitor
-version: 1.3.2
+version: 1.3.4
 appVersion: 1.3.0

--- a/_infra/templates/_helpers.tpl
+++ b/_infra/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 {{- define "datadog.labels" -}}
 {{- if .Values.datadog.enabled -}}
-tags.datadoghq.com/service: "tlsmonitor"
+tags.datadoghq.com/service: {{ include "tlsmonitor.fullname" . }}
 tags.datadoghq.com/version: {{ .Values.image.tag | quote }}
 team: {{ .Values.datadog.team }}
 {{- end }}

--- a/_infra/templates/_helpers.tpl
+++ b/_infra/templates/_helpers.tpl
@@ -30,3 +30,11 @@ Create chart name and version as used by the chart label.
 {{- define "tlsmonitor.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "datadog.labels" -}}
+{{- if .Values.datadog.enabled -}}
+tags.datadoghq.com/service: "tlsmonitor"
+tags.datadoghq.com/version: {{ .Values.image.tag | quote }}
+team: {{ .Values.datadog.team }}
+{{- end }}
+{{- end }}

--- a/_infra/templates/configmap.yaml
+++ b/_infra/templates/configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "tlsmonitor.fullname" . }}
+  labels:
+    app: {{ .Release.Name }}
+    {{- include "datadog.labels" . | nindent 4 }}
 data:
   config.yaml: |
     {{- tpl (.Files.Get "files/config.yaml") . | nindent 4 }}

--- a/_infra/templates/deployment.yaml
+++ b/_infra/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
 {{- end }}
       containers:
       - name: tlsmonitor
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version  }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
           - name: http-prom

--- a/_infra/templates/deployment.yaml
+++ b/_infra/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ .Release.Name }}
+{{- include "datadog.labels" . | nindent 4 }}
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -33,6 +34,7 @@ spec:
         app.kubernetes.io/name: {{ include "tlsmonitor.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: {{ .Release.Name }}
+{{- include "datadog.labels" . | nindent 8  }}
 {{- with .Values.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -47,6 +49,30 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/path: '{{ .Values.metrics.path }}'
         prometheus.io/port: '{{ .Values.metrics.port }}'
+{{- end }}
+{{- if .Values.istio.enabled }}
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ISTIO_META_DNS_CAPTURE: "false"
+            ISTIO_META_DNS_AUTO_ALLOCATE: "false"
+{{- end }}
+{{- if .Values.datadog.enabled }}
+        ad.datadoghq.com/tlsmonitor.logs: '[{"source": "go", "service": "tlsmonitor"}]'
+{{- if .Values.datadog.openMetricsCheckEnabled }}
+        ad.datadoghq.com/tlsmonitor.check_names: '["openmetrics"]'
+        ad.datadoghq.com/tlsmonitor.init_configs: "[{}]"
+        ad.datadoghq.com/tlsmonitor.instances: |
+          [
+            {
+              "openmetrics_endpoint": "<http://%%host%%:%%port%%/metrics>",
+              "namespace": "tlsmonitor",
+              "metrics": [
+                {"host_cert_expiration_seconds":"host_cert_expiration_seconds"},
+                {"file_cert_expiration_seconds":"file_cert_expiration_seconds"}
+              ]
+            }
+          ]
+{{- end }}
 {{- end }}
 {{- with .Values.pod.annotations }}
 {{ toYaml . | indent 8 }}

--- a/_infra/templates/istio-destination-rule.yaml
+++ b/_infra/templates/istio-destination-rule.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/instance: {{ $super.Release.Name }}
     app.kubernetes.io/managed-by: {{$super.Release.Service }}
     app: {{ $super.Release.Name }}
+    {{- include "datadog.labels" $super | nindent 4 }}
 spec:
   host: {{ . }}
   trafficPolicy:

--- a/_infra/templates/istio-service-entry.yaml
+++ b/_infra/templates/istio-service-entry.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ $super.Release.Name }}
     app.kubernetes.io/managed-by: {{$super.Release.Service }}
     app: {{ $super.Release.Name }}
+    {{- include "datadog.labels" $super | nindent 4 }}
 spec:
   hosts:
 {{- range .target }}

--- a/_infra/templates/istio-sidecar.yaml
+++ b/_infra/templates/istio-sidecar.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ .Release.Name }}
+    {{- include "datadog.labels" . | nindent 4 }}
 spec:
   egress:
   - hosts:

--- a/_infra/templates/pdb.yaml
+++ b/_infra/templates/pdb.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: {{ include "tlsmonitor.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Release.Name }}
+    {{- include "datadog.labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.pdb }}
   selector:

--- a/_infra/templates/podmonitor.yaml
+++ b/_infra/templates/podmonitor.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ .Release.Name }}
+{{- include "datadog.labels" . | nindent 4 }}
 {{- with .Values.deployment.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/_infra/templates/serviceaccount.yaml
+++ b/_infra/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: {{ .Release.Name }}
+    {{- include "datadog.labels" . | nindent 4 }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 automountServiceAccountToken: true

--- a/_infra/values.yaml
+++ b/_infra/values.yaml
@@ -49,7 +49,7 @@ pdb: 1
 
 nodeAffinity.key: {}
 
-globalLabels: {}
+labels: {}
 
 deployment:
   labels: {}
@@ -57,3 +57,8 @@ deployment:
 pod:
   labels: {}
   annotations: {}
+
+datadog:
+  enabled: false
+  openMetricsCheckEnabled: true
+  team: team_core_infrastructure

--- a/_infra/values.yaml
+++ b/_infra/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: ghcr.io/blablacar/tlsmonitor
   pullPolicy: IfNotPresent
 # Tag default to chart version
-# tag:
+#  tag:
 
 
 # List of endpoints to checks

--- a/_infra/values.yaml
+++ b/_infra/values.yaml
@@ -2,9 +2,11 @@
 # TLSmonitor helm chart
 
 image:
-  repository: geckosplinter/tlsmonitor
-  tag: 1.3.0
+  repository: ghcr.io/blablacar/tlsmonitor
   pullPolicy: IfNotPresent
+# Tag default to chart version
+# tag:
+
 
 # List of endpoints to checks
 hosts: []
@@ -61,4 +63,4 @@ pod:
 datadog:
   enabled: false
   openMetricsCheckEnabled: true
-  team: team_core_infrastructure
+  team: infra


### PR DESCRIPTION
chore: include datadog/istio labels and annotations by default when the associated flag is on