### PR TITLE
chore: Reduce alertDays to 28 days

### DIFF
--- a/pkg/tls/remoteCert.go
+++ b/pkg/tls/remoteCert.go
@@ -58,7 +58,7 @@ func CheckHostCert(target string, config *config.Config) {
 	timeNow := time.Now()
 	alertYears := 0
 	alertMonths := 0
-	alertDays := 40
+	alertDays := 28
 
 	for _, ip := range ips {
 		if ip.To4() != nil {


### PR DESCRIPTION
This would make it so the alerts are coming after cert manager already rotated the certs(30 days)